### PR TITLE
Replacing minimal base image with complete ubuntu to enable use with …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM python:3.11.9-slim
+FROM ubuntu:22.04
 
 LABEL authors="Gregoire Denay" \
       description="Docker image to run this package"
 
 RUN apt-get -y update
+RUN apt-get -y install python3-pip
 
 COPY requirements.txt ./
 


### PR DESCRIPTION
…Nextflow

Nextflow expects some basic linux utilities to be present inside the container. I have replaced the minimal python base image with a more complete ubuntu 22.04 (whcih also requires installating pip, of course). Seems to work fine when testing locally. 